### PR TITLE
fast and furious pos miner

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4350,7 +4350,9 @@ void BitcoinMiner(CWallet *pwallet, bool fProofOfStake)
                 CheckWork(pblock.get(), *pwalletMain, reservekey);
                 SetThreadPriority(THREAD_PRIORITY_LOWEST);
             }
-            Sleep(500);
+            // sairon: Fast and Furious Proof of Stake Miner
+            bool fFastPOS = GetArg("-fastpos", 0);
+            if (!fFastPOS) Sleep(500);
             continue;
         }
 


### PR DESCRIPTION
Added a new commandline switch for yacoind/yacoin-qt. Usage: run yacoind/yacoin-qt with "-fastpos=1" parameter to allow the PoS miner thread to use 100% of one CPU core (useful as a debugging feature or if you want to quickly mint PoS blocks and then shutdown the client).
