### PR TITLE
Change POS trust to equal POW trust after block 400000

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -1252,7 +1252,12 @@ public:
         bnTarget.SetCompact(nBits);
         if (bnTarget <= 0)
             return 0;
-        return (IsProofOfStake()? (CBigNum(1)<<256) / (bnTarget+1) : 1);
+        if (nHeight < 400000) {
+            return (IsProofOfStake()? (CBigNum(1)<<256) / (bnTarget+1) : 1);
+        }
+        else {
+            return 1;
+        }
     }
 
     bool IsInMainChain() const


### PR DESCRIPTION
YACoin was based on PPCoin, but YACoin has a different goal then PPCoin. PPCoin was intended to be a super green coin that doesn't waste electricity by requiring lots of computer power to generate POW blocks. So they designed PPCoin to eventually phase out POW. They did this by giving POS blocks much greater trust then POW blocks. But when a block has much more trust then the others, it has the potential to orphan a lot of blocks, potentially reversing confirmed transactions in the process. YACoin was created to be a CPU only coin, making it progressively harder to use GPUs as N increases. So it is not YACoin's original goal to phase out CPU mining at all! YACoiners have grown to like the interest payment POS offers, so we don't want to get rid of POS all together. But we can fix our problems with POS easily by simply changing POS trust to be equal to POW trust at some time in the future. I have selected block number 400000 as a nice round number for the change to take in effect.
