### PR TITLE
Allow brand new stake interest transactions into the QT transaction table

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -5,9 +5,9 @@
 
 /* Return positive answer if transaction should be shown in list.
  */
-bool TransactionRecord::showTransaction(const CWalletTx &wtx)
+bool TransactionRecord::showTransaction(const CWalletTx &wtx, bool testStake)
 {
-    if (wtx.IsCoinBase() || wtx.IsCoinStake())
+    if (wtx.IsCoinBase() || (testStake && wtx.IsCoinStake()))
     {
         // Ensures we show generated coins / mined transactions at depth 1
         if (!wtx.IsInMainChain())

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -96,7 +96,7 @@ public:
 
     /** Decompose CWallet transaction to model transaction records.
      */
-    static bool showTransaction(const CWalletTx &wtx);
+    static bool showTransaction(const CWalletTx &wtx, bool testStake=1);
     static QList<TransactionRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx);
 
     /** @name Immutable transaction attributes

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -104,7 +104,7 @@ public:
             bool inModel = (lower != upper);
 
             // Determine whether to show transaction or not
-            bool showTransaction = (inWallet && TransactionRecord::showTransaction(mi->second));
+            bool showTransaction = (inWallet && TransactionRecord::showTransaction(mi->second, false));
 
             if(status == CT_UPDATED)
             {


### PR DESCRIPTION
This change will allow brand new stake interest transactions from user's
just generated POS blocks to get entered into the QT transaction list.
If the new POS block gets orphaned, the transaction will get an undefined
status. But if the QT client is closed and re-opened, the orphaned stake
transaction will then disappear.
