### PR TITLE
Pause POS mining while current block is POS

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2347,7 +2347,7 @@ bool ProcessBlock(CNode* pfrom, CBlock* pblock)
         mapOrphanBlocksByPrev.erase(hashPrev);
     }
 
-    printf("ProcessBlock: ACCEPTED\n");
+    printf("ProcessBlock: ACCEPTED %s BLOCK\n", pblock->IsProofOfStake()?"POS":"POW");
 
     // ppcoin: if responsible for sync-checkpoint send it
     if (pfrom && !CSyncCheckpoint::strMasterPrivKey.empty())
@@ -4373,6 +4373,12 @@ void BitcoinMiner(CWallet *pwallet, bool fProofOfStake)
         //
         unsigned int nTransactionsUpdatedLast = nTransactionsUpdated;
         CBlockIndex* pindexPrev = pindexBest;
+
+        if (fProofOfStake && pindexPrev->IsProofOfStake()) {
+            bool fFastPOS = GetArg("-fastpos", 0);
+            if (!fFastPOS) Sleep(500);
+            continue;
+        }
 
         auto_ptr<CBlock> pblock(CreateNewBlock(pwallet, fProofOfStake));
         if (!pblock.get())


### PR DESCRIPTION
There is no point in creating POS blocks that will
automatically be orphaned by the new trust rules.
Hopefully this will reduce the number of those
annoying POS orphan transactions.

I also slipped in some extra debug output into
ProcessBlock().
